### PR TITLE
sort prefixes by size of CIDR block

### DIFF
--- a/blocklist.go
+++ b/blocklist.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/netip"
+	"sort"
 	"strings"
 
 	"go4.org/netipx"
@@ -113,5 +114,9 @@ func (c *Config) getAllURLs() []netip.Prefix {
 	if err != nil {
 		return []netip.Prefix{}
 	}
-	return prefixes.Prefixes()
+	pref := prefixes.Prefixes()
+	sort.Slice(pref, func(i, j int) bool {
+		return pref[i].Bits() < pref[j].Bits()
+	})
+	return pref
 }


### PR DESCRIPTION
Sorting the prefixes by size of CIDR block ensures that the minimum number of blocklists have to be searched for a given IP address. This might speed things up a bit.